### PR TITLE
Represent the arguments passed by the user as data structures in rust.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,0 +1,4 @@
+[root]
+name = "rust_cmdseq"
+version = "0.1.0"
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,43 @@
+fn string_collector(string: &str, start_white: usize, end_white: usize) -> String {
+    let mut collect = false;
+    let mut count_white = 0;
+    let mut collection = String::new();
+    for c in string.chars() {
+        if c == ' ' {
+            count_white = count_white + 1;
+            if !collect && (count_white == start_white || (count_white == 0 && start_white == 0)) { collect = !collect; }
+            else if count_white == end_white { return collection; }
+        } else if collect { collection.push(c); }
+    }
+    return collection;
+}
+
+fn build_command(arguments: std::iter::Skip<std::env::Args>) -> String {
+    let mut command = String::new();
+    for argument in arguments {
+        command = command + &argument + &" ".to_string();
+    }
+    String::from(command.trim_right())
+}
+
+fn load_cookie(directory: &str) { // Will return file handle in future.
+    println!("File path: {}", directory);
+}
+
+
+
 fn main() {
-    let mut c = 1;
     // Skip the first argument. It tells us the path to this executable.
     let passed_arguments = std::env::args().skip(1);
     if passed_arguments.len() <= 0 || passed_arguments.len() % 2 != 0 {
         println!("Usage: cmdseq [-d <count dir>] <count1> <cmd1> [... <countn> <cmdn>]");
         return; // terminate program.
     }
-    println!("Printing arguments passed:");
-    for argument in passed_arguments {
-        println!("{}: {}", c, argument);
-        c += 1;
-    }
+    let mut user_command = build_command(passed_arguments);
+    println!("Built string: {}", user_command);
+    if user_command.starts_with("-d ") {
+        load_cookie(&string_collector(&user_command, 1, 2));
+        user_command = string_collector(&user_command, 2, 0);
+    } else { load_cookie("/tmp"); }
+    println!("Finished with: {}", user_command);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,9 @@
 fn main() {
-    println!("Hello, world!");
+    let mut c = 1;
+    println!("Printing arguments passed:");
+    // Skip the first argument. It tells us the path to this executable.
+    for argument in std::env::args().skip(1) {
+        println!("{}: {}", c, argument);
+        c += 1;
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 fn string_collector(string: &str, start_white: usize, end_white: usize) -> String {
-    let mut collect = false;
+    let mut collecting = false;
+    let mut ignoring_white = false;
     let mut count_white = 0;
     let mut collection = String::new();
     for c in string.chars() {
-        if c == ' ' {
+        if c == '"' {
+            ignoring_white = !ignoring_white;
+            if collecting { collection.push(c); } // Quotes are kept when we are collecting
+        } else if !ignoring_white && c == ' ' {
             count_white = count_white + 1;
-            if !collect && (count_white == start_white || (count_white == 0 && start_white == 0)) { collect = !collect; }
+            if !collecting && (count_white == start_white || (count_white == 0 && start_white == 0)) { collecting = !collecting; }
             else if count_white == end_white { return collection; }
-        } else if collect { collection.push(c); }
+            else { collection.push(c); } // Don't skip spaces between start and end whites.
+        } else if collecting { collection.push(c); }
     }
     return collection;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-fn string_collector(string: &str, start_white: usize, end_white: usize) -> String {
+fn collect_between_white(string: &str, start_white: usize, end_white: usize) -> String {
     let mut collecting = false;
     let mut ignoring_white = false;
     let mut count_white = 0;
@@ -42,8 +42,8 @@ fn main() {
     let mut user_command = build_command(passed_arguments);
     println!("Built string: {}", user_command);
     if user_command.starts_with("-d ") {
-        load_cookie(&string_collector(&user_command, 1, 2));
-        user_command = string_collector(&user_command, 2, 0);
+        load_cookie(&collect_between_white(&user_command, 1, 2));
+        user_command = collect_between_white(&user_command, 2, 0);
     } else { load_cookie("/tmp"); }
     println!("Finished with: {}", user_command);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,8 @@ fn string_collector(string: &str, start_white: usize, end_white: usize) -> Strin
 fn build_command(arguments: std::iter::Skip<std::env::Args>) -> String {
     let mut command = String::new();
     for argument in arguments {
-        command = command + &argument + &" ".to_string();
+        command = if argument.contains(' ') { command + &"\"".to_string() + &argument + &"\" ".to_string() }
+        else { command + &argument + &" ".to_string() };
     }
     String::from(command.trim_right())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,20 @@
+struct CmdSeq {
+    times_before_next: usize,
+    cmd: String,
+}
+
+fn count_white_space(string: &str) -> usize {
+    let mut num_white: usize = 0;
+    let mut ignoring_white = false;
+    for c in string.chars() {
+        if !ignoring_white && c == ' ' { num_white = num_white + 1; }
+        else if c == '"' { ignoring_white = !ignoring_white; }
+    }
+    num_white
+}
+
 fn collect_between_white(string: &str, start_white: usize, end_white: usize) -> String {
-    let mut collecting = false;
+    let mut collecting = if start_white < 1 { true } else { false };
     let mut ignoring_white = false;
     let mut count_white = 0;
     let mut collection = String::new();
@@ -9,12 +24,12 @@ fn collect_between_white(string: &str, start_white: usize, end_white: usize) -> 
             if collecting { collection.push(c); } // Quotes are kept when we are collecting
         } else if !ignoring_white && c == ' ' {
             count_white = count_white + 1;
-            if !collecting && (count_white == start_white || (count_white == 0 && start_white == 0)) { collecting = !collecting; }
-            else if count_white == end_white { return collection; }
+            if !collecting && count_white == start_white { collecting = !collecting; }
+            else if count_white == end_white { return String::from(collection.trim_left()); } // Rid of extra space in beginning when collecting up until end.
             else { collection.push(c); } // Don't skip spaces between start and end whites.
         } else if collecting { collection.push(c); }
     }
-    return collection;
+    String::from(collection.trim_left())
 }
 
 fn build_command(arguments: std::iter::Skip<std::env::Args>) -> String {
@@ -30,7 +45,18 @@ fn load_cookie(directory: &str) { // Will return file handle in future.
     println!("File path: {}", directory);
 }
 
-
+fn get_command_list(command: &str) -> Vec<CmdSeq>{
+    let mut command_list: Vec<CmdSeq> = Vec::new();
+    let mut num = 0;
+    while num <= count_white_space(command) { // Using 'while' loop as 'step_by()' has issues atm.
+        command_list.push(CmdSeq {
+            times_before_next: collect_between_white(command, num, num + 1).parse().expect("Usage: cmdseq [-d <count dir>] <count1> <cmd1> [... <countn> <cmdn>]"),
+            cmd: collect_between_white(command, num + 1, num + 2)
+        });
+        num = num + 2;
+    }
+    command_list
+}
 
 fn main() {
     // Skip the first argument. It tells us the path to this executable.
@@ -40,10 +66,11 @@ fn main() {
         return; // terminate program.
     }
     let mut user_command = build_command(passed_arguments);
-    println!("Built string: {}", user_command);
     if user_command.starts_with("-d ") {
         load_cookie(&collect_between_white(&user_command, 1, 2));
-        user_command = collect_between_white(&user_command, 2, 0);
+        user_command = collect_between_white(&user_command, 2, 0); // Strip the this '-d' flag.
     } else { load_cookie("/tmp"); }
-    println!("Finished with: {}", user_command);
+    for cmdseq in get_command_list(&user_command) {
+        println!("CmdSeq\n  times_before_next: {}\n  cmd: {}", cmdseq.times_before_next, cmdseq.cmd);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,13 @@
 fn main() {
     let mut c = 1;
-    println!("Printing arguments passed:");
     // Skip the first argument. It tells us the path to this executable.
-    for argument in std::env::args().skip(1) {
+    let passed_arguments = std::env::args().skip(1);
+    if passed_arguments.len() <= 0 || passed_arguments.len() % 2 != 0 {
+        println!("Usage: cmdseq [-d <count dir>] <count1> <cmd1> [... <countn> <cmdn>]");
+        return; // terminate program.
+    }
+    println!("Printing arguments passed:");
+    for argument in passed_arguments {
         println!("{}: {}", c, argument);
         c += 1;
     }


### PR DESCRIPTION
- [x] Receive arguments from the command line in rust. Print them as a start.
- [x] Error handling for odd number of arguments entered or arguments omitted.
- [x] Handle "-d <directory>".
- [x] Represent the important arguments as a list of tuples.
